### PR TITLE
自动补全目录访问 优化

### DIFF
--- a/bin/nico
+++ b/bin/nico
@@ -211,6 +211,12 @@ function handler(req, res) {
     path.join(config.output, file), encode,
     function(err, data) {
       if (err) {
+        if (fs.existsSync(path.join(config.output, file, 'index.html'))) {
+          res.writeHead(302, {
+            'Location': req.url + '/'
+          });
+          return res.end();
+        }
         res.writeHead(404);
         logging.warn('request: [404] %s', req.url);
         return res.end('Not Found');


### PR DESCRIPTION
eg: 当无法访问 /tag/nico 时，判断是否存在/tag/nico/index.html 如果存在，则302跳转至 /tag/nico/
