### PR TITLE
dirname is replaced to '-'

### DIFF
--- a/lib/writers/base.js
+++ b/lib/writers/base.js
@@ -121,8 +121,13 @@ var BaseWriter = Class.create({
 
   // write file
   write: function(destination, content) {
-    destination = destination.replace(' ', '-');
+    // replace filename ' ' -> '-'
+    destination = destination.replace(/\/[^\/]*$/g, callback);
     pathlib.writeFileSync(destination, content);
+
+    function callback(str){
+      return str.replace(' ', '-');
+    }
   },
 
   end: function() {


### PR DESCRIPTION
Should not replace dirname

https://github.com/lepture/nico/blob/master/lib/writers/base.js#L124

```
write: function(destination, content) {
    destination = destination.replace(' ', '-');
    pathlib.writeFileSync(destination, content);
},
```
