### PR TITLE
 remove unnecessary toc herf encoding 

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -255,8 +255,9 @@ function getToc(content) {
   var renderer = new rs.HtmlRenderer();
   var toc = [];
   renderer.header = function(text, level) {
-    toc.push({id: text, text: text, level: level});
-    return util.format('<h%d id="%s">%s</h%d>', level, text, text, level);
+    var id = urilib.encode(text);
+    toc.push({id: id, text: text, level: level});
+    return util.format('<h%d id="%s">%s</h%d>', level, id, text, level);
   };
   var parser = new rs.Markdown(renderer);
   parser.render(content);
@@ -337,7 +338,8 @@ function getHtml(content, id) {
   };
 
   renderer.header = function(text, level) {
-    return util.format('<h%d id="%s">%s</h%d>', level, text, text, level);
+    var id = urilib.encode(text);
+    return util.format('<h%d id="%s">%s</h%d>', level, id, text, level);
   };
 
   var parser = new rs.Markdown(

--- a/lib/utils/urilib.js
+++ b/lib/utils/urilib.js
@@ -5,7 +5,7 @@ exports.encode = function(text) {
   var regex = /[^,\.<>\/\?;\:'"\[\]\{\}\\\|`~!@#\$%\^\&\*\(\)\_\+\=\s]+/g;
   text = text.match(regex).join('-').toLowerCase();
   text = text.replace(/-{2,}/g, '-');
-  return encodeURIComponent(text);
+  return text;
 };
 
 


### PR DESCRIPTION
At Firefox, the toc href will be automatically decoded.

Chinese word unnecessarily encoded, it work well in both chrome and firefox.
