### PR TITLE
自动刷新失效bugfix

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,9 +47,15 @@ function createWatch(app, fn) {
     io.sockets.on('connection', function(socket) {
       socket.emit('hello', {message: 'nico'});
 
-      events.on('sourceModified', function(message) {
+      var handle = function(message) {
         rebuild(socket, message);
+      };
+      
+      socket.on('disconnect', function(message){
+        events.removeListener('sourceModified', handle);
       });
+      
+      events.on('sourceModified', handle);
     });
   } else {
     events.on('sourceModified', function(message) {


### PR DESCRIPTION
如果不清除 sourceModified 绑定，刷新的是已经 disconnect 的 socket 对应的页面（因为最早绑定 sourceModified 事件），自动刷新机制失效
