### PR TITLE
file.contain bugfix

### DIFF
--- a/lib/sdk/file.js
+++ b/lib/sdk/file.js
@@ -32,7 +32,7 @@ file.cleanpath = function(filepath) {
 };
 
 file.contain = function(base, filepath) {
-  return path.relative(base, filepath).charAt(0) !== '.';
+  return path.resolve(base).indexOf(path.resolve(filepath)) === 0;
 };
 
 file.mkdir = function(dirpath, mode) {


### PR DESCRIPTION
windows里跨盘符的情况下，file.contain 返回的是错误的结果
