### PR TITLE
Add build markdown file error info.

### DIFF
--- a/lib/sdk/file.js
+++ b/lib/sdk/file.js
@@ -79,7 +79,12 @@ file.recurse = function recurse(rootdir, callback, subdir, filter) {
     if (fs.statSync(filepath).isDirectory()) {
       recurse(rootdir, callback, unixifyPath(path.join(subdir || '', filename)), filter);
     } else {
-      callback(unixifyPath(filepath), rootdir, subdir, filename);
+      try{
+        callback(unixifyPath(filepath), rootdir, subdir, filename);
+      }catch(ex){
+        log.error("build error", abspath+"/"+filename);
+        return;
+      }
     }
   });
 };


### PR DESCRIPTION
当编译 markdown 文件出现错误时，打印相关 markdown 文件信息。

但是最后会多打印一行信息， @lepture 可以看看是不是有更好的实现方式。

```
$ make build

           nico: 0.5.0
           load: nico.js
    build error: content/post/2013/multi-ssh-key-for-git.md
Assertion failed: (md->work_bufs[BUFFER_BLOCK].size == 0), function sd_markdown_render, file ../sundown/src/markdown.c, line 2528.
```