### PR TITLE
ignore dot files event if the file is under the subdir of sourcedir

### DIFF
--- a/lib/sdk/file.js
+++ b/lib/sdk/file.js
@@ -52,6 +52,18 @@ file.mkdir = function(dirpath, mode) {
   }, '');
 };
 
+file.isdotfile = function(filepath){
+  var ret = false;
+  var parts = filepath.split(path.sep);
+  for(var i=0, j=parts.length; i<j; i++){
+    if (parts[i]!=='' && parts[i].charAt(0)==='.'){
+      ret = true;
+      break;
+    }
+  }
+  return ret;
+};
+
 file.recurse = function recurse(rootdir, callback, subdir, filter) {
   if (_.isFunction(subdir)) {
     filter = subdir;
@@ -68,7 +80,7 @@ file.recurse = function recurse(rootdir, callback, subdir, filter) {
       return;
     }
     // ignore dotfiles
-    if (subdir && option.get('ignoredotfiles') !== false && subdir.charAt(0) === '.') {
+    if (subdir && option.get('ignoredotfiles') !== false && file.isdotfile(subdir)) {
       return;
     }
     // ignore cachedir directory


### PR DESCRIPTION
the former behaviour of option  ignoredotfiles will just check the files under sourcedir for one level, not recursively, which caused the following cases won't be ignored (option sourcedir set to 'content'):

content/aaa/.bbb
content/ccc/.ddd/fff
...
