### PR TITLE
fix issue#63: make dependency `markit` upgrade to 0.2.0 and fixed post title parsing problem

### DIFF
--- a/lib/sdk/post.js
+++ b/lib/sdk/post.js
@@ -284,7 +284,7 @@ exports.parse = parseContent;
 
 function parseMeta(content) {
     var html = md.markdown(content);
-    var m = html.match(/<h1>(.*?)<\/h1>/);
+    var m = html.match(/<h1 id=".*?">(.*?)<\/h1>/);
     var meta = {};
     if (!m) {
       meta.title = null;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "colorful": "~2.1.0",
     "highlight.js": "~7.5.0",
-    "markit": "~0.1.0",
+    "markit": "~0.2.0",
     "swig": "~0.14.0",
     "underscore": "~1.5.2",
     "rimraf": "~2.2.2",


### PR DESCRIPTION

`markit` v0.2.0 does generate head tag code snippet with id attribute which leads to
`html.match(/<h1>(.*?)<\/h1>/);` can not match anything.