### PR TITLE
Add build error info for users.

### DIFF
--- a/lib/sdk/post.js
+++ b/lib/sdk/post.js
@@ -98,9 +98,14 @@ exports.read = function(filepath, fromCache) {
 
   // markdown parse everything
   option.set('iframeId', encode.uri(post.filename));
-  post.html = md.render(post.body);
-  post.toc = parseToc(post.body);
-  post.iframes = md.iframes(post.body);
+
+  try {
+    post.html = md.render(post.body);
+    post.toc = parseToc(post.body);
+    post.iframes = md.iframes(post.body);
+  } catch (ex) {
+    log.error('build', filepath + ' error with message: ' + ex.message.split(/\r\n|\r|\n/)[0]);
+  }
 
   // user can customize post
   post = runReader(post);


### PR DESCRIPTION
before:

```
$ nico server --watch 

           nico: 0.5.1
           load: nico.js
/usr/local/lib/node_modules/nico/node_modules/markit/index.js:1102
      throw e;
            ^
TypeError: Cannot read property 'slice' of null
Please report this to https://github.com/chjj/marked.
    at Renderer.exports.blockcode (/usr/local/lib/node_modules/nico/lib/sdk/markdown/_share.js:34:15)
    at Parser.tok (/usr/local/lib/node_modules/nico/node_modules/markit/index.js:927:23)
    at Parser.tok (/usr/local/lib/node_modules/nico/node_modules/markit/index.js:988:18)
    at Parser.tok (/usr/local/lib/node_modules/nico/node_modules/markit/index.js:978:22)
    at Parser.tok (/usr/local/lib/node_modules/nico/node_modules/markit/index.js:988:18)
    at Parser.tok (/usr/local/lib/node_modules/nico/node_modules/markit/index.js:978:22)
    at Parser.parse (/usr/local/lib/node_modules/nico/node_modules/markit/index.js:870:17)
    at Function.Parser.parse (/usr/local/lib/node_modules/nico/node_modules/markit/index.js:857:17)
    at marked (/usr/local/lib/node_modules/nico/node_modules/markit/index.js:1081:22)
    at hlMarkdown (/usr/local/lib/node_modules/nico/lib/sdk/markdown/marked.js:20:10)
```

now:

```
$ nico server --watch

           nico: 0.5.1
           load: nico.js
          build: wiki/Canvas-SVG-VML.md error with message: Cannot read property 'slice' of null
          build: wiki/Flex.md error with message: Cannot read property 'slice' of null
          build: wiki/JavaScript.md error with message: Cannot read property 'slice' of null
           load: PageWriter
           load: PostWriter
           load: FileWriter
           load: StaticWriter
            run: PageWriter
          write: 269 pages
          build: wiki/Canvas-SVG-VML.md error with message: Cannot read property 'slice' of null
          build: wiki/Flex.md error with message: Cannot read property 'slice' of null
          build: wiki/JavaScript.md error with message: Cannot read property 'slice' of null
            run: PostWriter
            run: FileWriter
            run: StaticWriter
           copy: theme/static -> _site/static
           time: 1.933s
           load: nico.js
          watch: wiki
          watch: theme
         server: http://127.0.0.1:8000
```

![2015-05-14 23 18 54](https://cloud.githubusercontent.com/assets/143572/7634787/c00a54a2-fa8f-11e4-817c-2464800ff804.png)


Most of build error is because of code language is not support, like `viml`..