### PR TITLE
should not autolink when parseMeta

### DIFF
--- a/lib/sdk/post.js
+++ b/lib/sdk/post.js
@@ -288,6 +288,9 @@ function parseContent(content) {
 exports.parse = parseContent;
 
 function parseMeta(content) {
+    md.markdown.setOptions({
+      gfm: false
+    });
     var html = md.markdown(content);
     var m = html.match(/<h1>(.*?)<\/h1>/);
     var meta = {};


### PR DESCRIPTION
```md
# title

- url: http://github.com

---

content
```

`post.meta.url` should be `http://github.com` rather then `<a href="http://github.com">http://github.com</a>`